### PR TITLE
utiliser mode markdown par default

### DIFF
--- a/server/post/POST_this.js
+++ b/server/post/POST_this.js
@@ -20,7 +20,7 @@ module.exports = app.post('/', [body('contenu').notEmpty().isLength({ max: 4000 
     const resultatValidation = validationResult(req);
     if (resultatValidation.isEmpty()) {
 
-        const estMarkdown = req.body.est_markdown;
+        const estMarkdown = true;
         const titre = req.body.titre;
         const contenu = req.body.contenu;
         const idToken = req.headers.authorization;


### PR DESCRIPTION
Utiliser le mode markdown par défaut. Ça me tentait pas de remettre la switch qui est disparue durant les merges de branches alors je me suis dit que ca serait plus simple d'activer markdown par défaut pour tout le monde. 


**Les posts plain text de base sans formattaage continuent de fonctionner**