### PR TITLE
Utiliser .env pour stocker l'emplacement de la clé

### DIFF
--- a/server/serveur.js
+++ b/server/serveur.js
@@ -11,7 +11,7 @@ const rateLimit = require('express-rate-limit')
 
 dotenv.config();
 
-let firebaseKeyLocation = process.env.GOOGLE_APPLICATION_CREDENTIALS || "./firebaseServiceAccountKey.json"
+let firebaseKeyLocation = process.env.GOOGLE_APPLICATION_CREDENTIALS
 
 exports.admin = admin.initializeApp({
     credential: admin.credential.cert(firebaseKeyLocation),


### PR DESCRIPTION
Vous devriez mettre votre .env a jour 

`GOOGLE_APPLICATION_CREDENTIALS="/home/user/klemn/firebaseServiceAccountKey.json"`